### PR TITLE
FIX typo for binder < 10 >

### DIFF
--- a/sqlite_modern_cpp.h
+++ b/sqlite_modern_cpp.h
@@ -538,7 +538,7 @@ namespace sqlite {
 			dbb.get_col_from_db(7, col_8);
 			type_9 col_9;
 			dbb.get_col_from_db(8, col_9);
-			type_9 col_10;
+			type_10 col_10;
 			dbb.get_col_from_db(9, col_10);
 
 			l(std::move(col_1), std::move(col_2), std::move(col_3), std::move(col_4), std::move(col_5), std::move(col_6), std::move(col_7), std::move(col_8), std::move(col_9), std::move(col_10));


### PR DESCRIPTION
I found a typo for `binder < 10 >`, while declaring `col_10`. It should be `type_10`.

Besides this, is there any way to declare a callback with any number of arguments?
I've been playing with this for a while, and all I could do at the moment is just add more binder struct for each of arguments I need.

