### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: cpp
+sudo: required
+dist: trusty
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-5
+      - g++-5
+      - libsqlite3-dev
+
+before_install:
+  - export CXX="g++-5" CC="gcc-5"


### PR DESCRIPTION
You should've waited a few minutes and let me cleanup. You integrated a version of the `.travis.yml` that is not working correctly (libsqlite3-dev is too old on 12.04) and you polluted your history with many test commits that were never meant to appear anywhere (just to trigger travis-ci).

You might want to consider doing what is evil beyond measure and `push --force` a cleaned history (squash my many commits into a single one).