### PR TITLE
Removed potentially-misleading dead code and comment

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -280,8 +280,8 @@ namespace sqlite {
 			sqlite3* tmp = nullptr;
 			auto ret = sqlite3_open16(db_name.data(), &tmp);
 			if(ret != SQLITE_OK) exceptions::throw_sqlite_error(ret);
-			_db = std::shared_ptr<sqlite3>(tmp, [=](sqlite3* ptr) { sqlite3_close_v2(ptr); ptr = nullptr; }); // close and null to be sure
-																											  //_db.reset(tmp, sqlite3_close); // alternative close. (faster?)
+			_db = std::shared_ptr<sqlite3>(tmp, [=](sqlite3* ptr) { sqlite3_close_v2(ptr); });
+																	//_db.reset(tmp, sqlite3_close); // alternative close. (faster?)
 		}
 
 		database(std::string const & db_name):


### PR DESCRIPTION
Since ptr is being passed by value to the lambda expression,
setting ptr to null will have no effect past that single line.

The combination of the code and the comment which implies there
is an additional benefit/security in doing so might mislead a
maintainer or developer down the road.