### PR TITLE
support nullptr and uniqueptr

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -215,6 +215,7 @@ namespace sqlite {
 		template<typename T> friend void get_col_from_db(database_binder& db, int inx, std::vector<T>& val);
 		/* for nullptr & unique_ptr support */
 		friend database_binder::chain_type& operator <<(database_binder::chain_type& db, std::nullptr_t);
+		template<typename T> friend database_binder::chain_type& operator <<(database_binder::chain_type& db, const std::unique_ptr<T>& val);
 		template<typename T> friend void get_col_from_db(database_binder& db, int inx, std::unique_ptr<T>& val);
 		template<typename T> friend T operator++(database_binder& db, int);
 
@@ -469,6 +470,14 @@ namespace sqlite {
 			exceptions::throw_sqlite_error(hresult);
 		}
 		++db->_inx;
+		return db;
+	}
+	/* for nullptr support */
+	template<typename T> inline database_binder::chain_type& operator <<(database_binder::chain_type& db, const std::unique_ptr<T>& val) {
+		if(val)
+			db << *val;
+		else
+		  db << nullptr;
 		return db;
 	}
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -210,8 +210,12 @@ namespace sqlite {
 
 		template<typename T> friend database_binder::chain_type& operator <<(database_binder::chain_type& db, const T& val);
 		template<typename T> friend void get_col_from_db(database_binder& db, int inx, T& val);
+		/* for vector<T> support */
 		template<typename T> friend database_binder::chain_type& operator <<(database_binder::chain_type& db, const std::vector<T>& val);
 		template<typename T> friend void get_col_from_db(database_binder& db, int inx, std::vector<T>& val);
+		/* for nullptr & unique_ptr support */
+		friend database_binder::chain_type& operator <<(database_binder::chain_type& db, std::nullptr_t);
+		template<typename T> friend void get_col_from_db(database_binder& db, int inx, std::unique_ptr<T>& val);
 		template<typename T> friend T operator++(database_binder& db, int);
 
 
@@ -455,6 +459,27 @@ namespace sqlite {
 			int bytes = sqlite3_column_bytes(db._stmt.get(), inx);
 			T const* buf = reinterpret_cast<T const *>(sqlite3_column_blob(db._stmt.get(), inx));
 			vec = std::vector<T>(buf, buf + bytes/sizeof(T));
+		}
+	}
+
+	/* for nullptr support */
+	inline database_binder::chain_type& operator <<(database_binder::chain_type& db, std::nullptr_t) {
+		int hresult;
+		if((hresult = sqlite3_bind_null(db->_stmt.get(), db->_inx)) != SQLITE_OK) {
+			exceptions::throw_sqlite_error(hresult);
+		}
+		++db->_inx;
+		return db;
+	}
+
+	/* for unique_ptr<T> support */
+	template<typename T> inline void get_col_from_db(database_binder& db, int inx, std::unique_ptr<T>& _ptr_) {
+		if(sqlite3_column_type(db._stmt.get(), inx) == SQLITE_NULL) {
+			_ptr_ = nullptr;
+		} else {
+			auto underling_ptr = new T();
+			get_col_from_db(db, inx, *underling_ptr);
+			_ptr_.reset(underling_ptr);
 		}
 	}
 

--- a/tests/nullptr_uniqueptr.cc
+++ b/tests/nullptr_uniqueptr.cc
@@ -11,7 +11,8 @@ int main() {
 		database db(":memory:");
 		db << "CREATE TABLE tbl (id integer,age integer, name string, img blob);";
 		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 1 << 24 << "bob" << vector<int> { 1, 2 , 3};
-		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 2 << nullptr << nullptr << nullptr;
+    unique_ptr<string> ptr_null;
+		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 2 << nullptr << ptr_null << nullptr;
 
 		db << "select age,name,img from tbl where id = 1" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
       if(age_p == nullptr || name_p == nullptr || img_p == nullptr) {

--- a/tests/nullptr_uniqueptr.cc
+++ b/tests/nullptr_uniqueptr.cc
@@ -7,14 +7,14 @@ using namespace sqlite;
 
 int main() {
 
-	try {
-		database db(":memory:");
-		db << "CREATE TABLE tbl (id integer,age integer, name string, img blob);";
-		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 1 << 24 << "bob" << vector<int> { 1, 2 , 3};
+  try {
+    database db(":memory:");
+    db << "CREATE TABLE tbl (id integer,age integer, name string, img blob);";
+    db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 1 << 24 << "bob" << vector<int> { 1, 2 , 3};
     unique_ptr<string> ptr_null;
-		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 2 << nullptr << ptr_null << nullptr;
+    db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 2 << nullptr << ptr_null << nullptr;
 
-		db << "select age,name,img from tbl where id = 1" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
+    db << "select age,name,img from tbl where id = 1" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
       if(age_p == nullptr || name_p == nullptr || img_p == nullptr) {
         cerr << "ERROR: values should not be null" << std::endl;
         exit(EXIT_FAILURE);
@@ -22,26 +22,26 @@ int main() {
 
       cout << "age:" << *age_p << " name:" << *name_p << " img:";
       for(auto i : *img_p) cout << i << ","; cout << endl;
-		};
+    };
 
-		db << "select age,name,img from tbl where id = 2" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
+    db << "select age,name,img from tbl where id = 2" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
       if(age_p != nullptr || name_p != nullptr || img_p != nullptr) {
         cerr << "ERROR: values should be nullptr" << std::endl;
         exit(EXIT_FAILURE);
       }
 
       cout << "OK all three values are nullptr" << endl;
-		};
+    };
 
-	} catch(sqlite_exception e) {
-		cout << "Sqlite error " << e.what() << endl;
-		exit(EXIT_FAILURE);
-	} catch(...) {
-		cout << "Unknown error\n";
-		exit(EXIT_FAILURE);
-	}
+  } catch(sqlite_exception e) {
+    cout << "Sqlite error " << e.what() << endl;
+    exit(EXIT_FAILURE);
+  } catch(...) {
+    cout << "Unknown error\n";
+    exit(EXIT_FAILURE);
+  }
 
-	cout << "OK\n";
-	exit(EXIT_SUCCESS);
+  cout << "OK\n";
+  exit(EXIT_SUCCESS);
   return 0;
 }

--- a/tests/nullptr_uniqueptr.cc
+++ b/tests/nullptr_uniqueptr.cc
@@ -1,0 +1,46 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sqlite_modern_cpp.h>
+using namespace std;
+using namespace sqlite;
+
+int main() {
+
+	try {
+		database db(":memory:");
+		db << "CREATE TABLE tbl (id integer,age integer, name string, img blob);";
+		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 1 << 24 << "bob" << vector<int> { 1, 2 , 3};
+		db << "INSERT INTO tbl VALUES (?, ?, ?, ?);" << 2 << nullptr << nullptr << nullptr;
+
+		db << "select age,name,img from tbl where id = 1" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
+      if(age_p == nullptr || name_p == nullptr || img_p == nullptr) {
+        cerr << "ERROR: values should not be null" << std::endl;
+        exit(EXIT_FAILURE);
+      }
+
+      cout << "age:" << *age_p << " name:" << *name_p << " img:";
+      for(auto i : *img_p) cout << i << ","; cout << endl;
+		};
+
+		db << "select age,name,img from tbl where id = 2" >> [](unique_ptr<int> age_p, unique_ptr<string> name_p, unique_ptr<vector<int>> img_p) {
+      if(age_p != nullptr || name_p != nullptr || img_p != nullptr) {
+        cerr << "ERROR: values should be nullptr" << std::endl;
+        exit(EXIT_FAILURE);
+      }
+
+      cout << "OK all three values are nullptr" << endl;
+		};
+
+	} catch(sqlite_exception e) {
+		cout << "Sqlite error " << e.what() << endl;
+		exit(EXIT_FAILURE);
+	} catch(...) {
+		cout << "Unknown error\n";
+		exit(EXIT_FAILURE);
+	}
+
+	cout << "OK\n";
+	exit(EXIT_SUCCESS);
+  return 0;
+}


### PR DESCRIPTION
@Killili  The most important downside with #51 is that users can only figure out that a value is null or not.

I was thinking that maybe overloading on `nullptr` and `uniqueptr<T>` can solve this problem.
And we can even deprecate boost optional.

Take a look at the new test.