### PR TITLE
Fix build for modern standard libraries

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -9,12 +9,12 @@
 #include <vector>
 
 #ifdef __has_include
-#if __has_include(<optional>)
-#define _MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+#if __cplusplus > 201402 && __has_include(<optional>)
+#define MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #endif
 #endif
 
-#ifdef _MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #include <optional>
 #endif
 
@@ -276,7 +276,7 @@ namespace sqlite {
 		friend database_binder& operator <<(database_binder& db, const std::u16string& txt);
 
 
-#ifdef _MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val);
 		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, std::optional<OptionalT>& o);
 #endif
@@ -791,7 +791,7 @@ namespace sqlite {
 		 sqlite3_result_text16(db, val.data(), -1, SQLITE_TRANSIENT);
 	}
 	// std::optional support for NULL values
-#ifdef _MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val) {
 		if(val) {
 			return operator << (std::move(db), std::move(*val));

--- a/tests/std_optional.cc
+++ b/tests/std_optional.cc
@@ -6,7 +6,7 @@
 using namespace sqlite;
 using namespace std;
 
-#if __has_include(<optional>)
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 void insert(database& db, bool is_null) {
 	int id = 1;
 	std::optional<int> val;


### PR DESCRIPTION
The current build breaks, iff the standard library supports `<optional>`, but C++17 support isn't enabled.
Additionally we should not use _Reserved identifiers.
@aminroosta Should we make a bugfix release(3.0.1?) out of this?