### PR TITLE
std::variant support

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,8 @@ If your columns may have flexible types, you can use C++17's `std::variant` to e
 
 ```c++
 db << "CREATE TABLE tbl (id integer, data);";
-db << "INSERT INTO tbl VALUES (?, ?, ?);" << 1 << vector<int> { 1, 2, 3};
-unique_ptr<string> ptr_null; // you can even bind empty unique_ptr<T>
-db << "INSERT INTO tbl VALUES (?, ?, ?);" << 2 << 2.5;
+db << "INSERT INTO tbl VALUES (?, ?);" << 1 << vector<int> { 1, 2, 3};
+db << "INSERT INTO tbl VALUES (?, ?);" << 2 << 2.5;
 
 db << "select data from tbl where id = 1"
 		>> [](std::variant<vector<int>, double> data) {
@@ -355,7 +354,7 @@ db << "select data from tbl where id = 1"
 			for(auto i : get<vector<int>>(data)) cout << i << ","; cout << endl;
 		};
 
-db << "select age,name,img from tbl where id = 2"
+db << "select data from tbl where id = 2"
 		>> [](std::variant<vector<int>, double> data) {
 			if(data.index() != 2) {
 				cerr << "ERROR: we expected a real number" << std::endl;

--- a/README.md
+++ b/README.md
@@ -336,6 +336,41 @@ You can enable boost support by defining _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT b
 	}
 ```
 
+Variant type support (C++17)
+----
+If your columns may have flexible types, you can use C++17's `std::variant` to extract the value.
+
+```c++
+db << "CREATE TABLE tbl (id integer, data);";
+db << "INSERT INTO tbl VALUES (?, ?, ?);" << 1 << vector<int> { 1, 2, 3};
+unique_ptr<string> ptr_null; // you can even bind empty unique_ptr<T>
+db << "INSERT INTO tbl VALUES (?, ?, ?);" << 2 << 2.5;
+
+db << "select data from tbl where id = 1"
+		>> [](std::variant<vector<int>, double> data) {
+			if(data.index() != 1) {
+				cerr << "ERROR: we expected a blob" << std::endl;
+			}
+
+			for(auto i : get<vector<int>>(data)) cout << i << ","; cout << endl;
+		};
+
+db << "select age,name,img from tbl where id = 2"
+		>> [](std::variant<vector<int>, double> data) {
+			if(data.index() != 2) {
+				cerr << "ERROR: we expected a real number" << std::endl;
+			}
+
+			cout << get<double>(data) << endl;
+		};
+```
+
+If you read a specific type and this type does not match the actual type in the SQlite database, yor data will be converted.
+This does not happen if you use a `variant`.
+If the `variant` does an alternative of the same value type, an `mismatch` exception will be thrown.
+The value types are NULL, integer, real number, text and BLOB.
+To support all possible values, you can use `variant<nullptr_t, sqlite_int64, double, string, vector<char>`.
+
 Errors
 ----
 

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -16,6 +16,12 @@
 #endif
 #endif
 
+#ifdef __has_include
+#if __cplusplus > 201402 && __has_include(<variant>)
+#define MODERN_SQLITE_STD_VARIANT_SUPPORT
+#endif
+#endif
+
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #include <optional>
 #endif
@@ -895,6 +901,14 @@ namespace sqlite {
 		}
 	}
 #endif
+
+	template <typename ...Args> inline database_binder& operator <<(database_binder& db, const std::variant<Args...>& val) {
+    std::visit([&](auto &&opt) {db << std::forward<decltype(opt)>(opt);}, val);
+		return db;
+	}
+	template <typename ...Args> inline void store_result_in_db(sqlite3_context* db, const std::variant<Args...>& val) {
+    std::visit([&](auto &&opt) {store_result_in_db(db, std::forward<decltype(opt)>(opt));}, val);
+	}
 
 	// Some ppl are lazy so we have a operator for proper prep. statemant handling.
 	void inline operator++(database_binder& db, int) { db.execute(); db.reset(); }

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -1065,7 +1065,7 @@ namespace sqlite {
 
 		template<
 			std::size_t Count,
-			typename		Function,
+			typename    Function,
 			typename... Values
 		>
 		inline typename std::enable_if<(sizeof...(Values) == Count), void>::type scalar(

--- a/hdr/sqlite_modern_cpp/utility/variant.h
+++ b/hdr/sqlite_modern_cpp/utility/variant.h
@@ -1,0 +1,200 @@
+#pragma once
+
+#include <sqlite3.h>
+#include <optional>
+#include <variant>
+
+namespace sqlite::utility {
+	template<typename ...Options>
+	struct VariantFirstNullable {
+		using type = void;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstNullable<T, Options...> {
+		using type = typename VariantFirstNullable<Options...>::type;
+	};
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	template<typename T, typename ...Options>
+	struct VariantFirstNullable<std::optional<T>, Options...> {
+		using type = std::optional<T>;
+	};
+#endif
+	template<typename T, typename ...Options>
+	struct VariantFirstNullable<std::unique_ptr<T>, Options...> {
+		using type = std::unique_ptr<T>;
+	};
+	template<typename ...Options>
+	struct VariantFirstNullable<std::nullptr_t, Options...> {
+		using type = std::nullptr_t;
+	};
+	template<typename Callback, typename ...Options>
+	inline void variant_select_null(Callback&&callback) {
+		if constexpr(std::is_same_v<typename VariantFirstNullable<Options...>::type, void>) {
+			throw exceptions::mismatch("NULL is unsupported by this variant.", "", SQLITE_MISMATCH);
+		} else {
+			std::forward<Callback>(callback)(typename VariantFirstNullable<Options...>::type());
+		}
+	}
+
+	template<typename ...Options>
+	struct VariantFirstIntegerable {
+		using type = void;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstIntegerable<T, Options...> {
+		using type = typename VariantFirstIntegerable<Options...>::type;
+	};
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	template<typename T, typename ...Options>
+	struct VariantFirstIntegerable<std::optional<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstIntegerable<T, Options...>::type, T>, std::optional<T>, typename VariantFirstIntegerable<Options...>::type>;
+	};
+#endif
+	template<typename T, typename ...Options>
+	struct VariantFirstIntegerable<std::enable_if_t<std::is_same_v<typename VariantFirstIntegerable<T, Options...>::type, T>>, std::unique_ptr<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstIntegerable<T, Options...>::type, T>, std::unique_ptr<T>, typename VariantFirstIntegerable<Options...>::type>;
+	};
+	template<typename ...Options>
+	struct VariantFirstIntegerable<int, Options...> {
+		using type = int;
+	};
+	template<typename ...Options>
+	struct VariantFirstIntegerable<sqlite_int64, Options...> {
+		using type = sqlite_int64;
+	};
+	template<typename Callback, typename ...Options>
+	inline auto variant_select_integer(Callback&&callback) {
+		if constexpr(std::is_same_v<typename VariantFirstIntegerable<Options...>::type, void>) {
+			throw exceptions::mismatch("Integer is unsupported by this variant.", "", SQLITE_MISMATCH);
+		} else {
+			std::forward<Callback>(callback)(typename VariantFirstIntegerable<Options...>::type());
+		}
+	}
+
+	template<typename ...Options>
+	struct VariantFirstFloatable {
+		using type = void;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstFloatable<T, Options...> {
+		using type = typename VariantFirstFloatable<Options...>::type;
+	};
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	template<typename T, typename ...Options>
+	struct VariantFirstFloatable<std::optional<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstFloatable<T, Options...>::type, T>, std::optional<T>, typename VariantFirstFloatable<Options...>::type>;
+	};
+#endif
+	template<typename T, typename ...Options>
+	struct VariantFirstFloatable<std::unique_ptr<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstFloatable<T, Options...>::type, T>, std::unique_ptr<T>, typename VariantFirstFloatable<Options...>::type>;
+	};
+	template<typename ...Options>
+	struct VariantFirstFloatable<float, Options...> {
+		using type = float;
+	};
+	template<typename ...Options>
+	struct VariantFirstFloatable<double, Options...> {
+		using type = double;
+	};
+	template<typename Callback, typename ...Options>
+	inline auto variant_select_float(Callback&&callback) {
+		if constexpr(std::is_same_v<typename VariantFirstFloatable<Options...>::type, void>) {
+			throw exceptions::mismatch("Real is unsupported by this variant.", "", SQLITE_MISMATCH);
+		} else {
+			std::forward<Callback>(callback)(typename VariantFirstFloatable<Options...>::type());
+		}
+	}
+
+	template<typename ...Options>
+	struct VariantFirstTextable {
+		using type = void;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstTextable<T, Options...> {
+		using type = typename VariantFirstTextable<void, Options...>::type;
+	};
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	template<typename T, typename ...Options>
+	struct VariantFirstTextable<std::optional<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstTextable<T, Options...>::type, T>, std::optional<T>, typename VariantFirstTextable<Options...>::type>;
+	};
+#endif
+	template<typename T, typename ...Options>
+	struct VariantFirstTextable<std::unique_ptr<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstTextable<T, Options...>::type, T>, std::unique_ptr<T>, typename VariantFirstTextable<Options...>::type>;
+	};
+	template<typename ...Options>
+	struct VariantFirstTextable<std::string, Options...> {
+		using type = std::string;
+	};
+	template<typename ...Options>
+	struct VariantFirstTextable<std::u16string, Options...> {
+		using type = std::u16string;
+	};
+	template<typename Callback, typename ...Options>
+	inline void variant_select_text(Callback&&callback) {
+		if constexpr(std::is_same_v<typename VariantFirstTextable<Options...>::type, void>) {
+			throw exceptions::mismatch("Text is unsupported by this variant.", "", SQLITE_MISMATCH);
+		} else {
+			std::forward<Callback>(callback)(typename VariantFirstTextable<Options...>::type());
+		}
+	}
+
+	template<typename ...Options>
+	struct VariantFirstBlobable {
+		using type = void;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstBlobable<T, Options...> {
+		using type = typename VariantFirstBlobable<Options...>::type;
+	};
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	template<typename T, typename ...Options>
+	struct VariantFirstBlobable<std::optional<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstBlobable<T, Options...>::type, T>, std::optional<T>, typename VariantFirstBlobable<Options...>::type>;
+	};
+#endif
+	template<typename T, typename ...Options>
+	struct VariantFirstBlobable<std::unique_ptr<T>, Options...> {
+		using type = std::conditional_t<std::is_same_v<typename VariantFirstBlobable<T, Options...>::type, T>, std::unique_ptr<T>, typename VariantFirstBlobable<Options...>::type>;
+	};
+	template<typename T, typename ...Options>
+	struct VariantFirstBlobable<std::enable_if_t<std::is_pod_v<T>>, std::vector<T>, Options...> {
+		using type = std::vector<T>;
+	};
+	template<typename Callback, typename ...Options>
+	inline auto variant_select_blob(Callback&&callback) {
+		if constexpr(std::is_same_v<typename VariantFirstBlobable<Options...>::type, void>) {
+			throw exceptions::mismatch("Blob is unsupported by this variant.", "", SQLITE_MISMATCH);
+		} else {
+			std::forward<Callback>(callback)(typename VariantFirstBlobable<Options...>::type());
+		}
+	}
+
+	template<typename ...Options>
+	inline auto variant_select(int type) {
+		return [type](auto &&callback) {
+			using Callback = decltype(callback);
+			switch(type) {
+				case SQLITE_NULL:
+					variant_select_null<Callback, Options...>(std::forward<Callback>(callback));
+					break;
+				case SQLITE_INTEGER:
+					variant_select_integer<Callback, Options...>(std::forward<Callback>(callback));
+					break;
+				case SQLITE_FLOAT:
+					variant_select_float<Callback, Options...>(std::forward<Callback>(callback));
+					break;
+				case SQLITE_TEXT:
+					variant_select_text<Callback, Options...>(std::forward<Callback>(callback));
+					break;
+				case SQLITE_BLOB:
+					variant_select_blob<Callback, Options...>(std::forward<Callback>(callback));
+					break;
+				default:;
+					/* assert(false); */
+			}
+		};
+	}
+}

--- a/tests/variant.cc
+++ b/tests/variant.cc
@@ -1,0 +1,57 @@
+#include <iostream>
+#include <cstdlib>
+#include <sqlite_modern_cpp.h>
+using namespace sqlite;
+using namespace std;
+
+int main()
+{
+#ifdef MODERN_SQLITE_STD_VARIANT_SUPPORT
+	try
+	{
+		database db(":memory:");
+
+		db << "CREATE TABLE foo (a);";
+		std::variant<std::string, int, std::optional<float>> v;
+		v = 1;
+		db << "INSERT INTO foo VALUES (?)" << v;
+		v = "a";
+		db << "INSERT INTO foo VALUES (?)" << v;
+
+		db << "SELECT a FROM foo WHERE a=?;" << 1 >> v;
+
+		if(v.index() != 1 || std::get<1>(v) != 1)
+		{
+			cout << "Bad result on line " << __LINE__ << endl;
+			exit(EXIT_FAILURE);
+		}
+
+		db << "SELECT NULL" >> v;
+		if(std::get<2>(v)) {
+			cout << "Bad result on line " << __LINE__ << endl;
+			exit(EXIT_FAILURE);
+		}
+
+		db << "SELECT 0.0" >> v;
+		if(!std::get<2>(v)) {
+			cout << "Bad result on line " << __LINE__ << endl;
+			exit(EXIT_FAILURE);
+		}
+	}
+	catch(sqlite_exception e)
+	{
+		cout << "Unexpected error " << e.what() << endl;
+		exit(EXIT_FAILURE);
+	}
+	catch(...)
+	{
+		cout << "Unknown error\n";
+		exit(EXIT_FAILURE);
+	}
+
+	cout << "OK\n";
+	exit(EXIT_SUCCESS);
+#else
+	exit(42);
+#endif
+}


### PR DESCRIPTION
The motivating use case for this are custom functions. With `variant`s you can create functions with flexible argument/return types.