### PR TITLE
Fix exceptions so they can be caught by const reference

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -43,8 +43,8 @@ namespace sqlite {
 	public:
 		sqlite_exception(const char* msg, std::string sql, int code = -1): runtime_error(msg), code(code), sql(sql) {}
 		sqlite_exception(int code, std::string sql): runtime_error(sqlite3_errstr(code)), code(code), sql(sql) {}
-		int get_code() {return code;}
-		std::string get_sql() {return sql;}
+		int get_code() const {return code;}
+		std::string get_sql() const {return sql;}
 	private:
 		int code;
 		std::string sql;


### PR DESCRIPTION
I am not sure if I am making the pull request to the right branch or if I have missed something, but the methods of the exception class on the main branch do not allow the exceptions to be caught by const reference as is normally recommended to do.

Modifying the methods to be const fixes the issue.