### PR TITLE
adding sqlite::endr, and ability to give functions to database_binder

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -91,6 +91,10 @@ namespace sqlite {
 			}
 			
 		}
+		void endr() {
+		  execute();
+		  reset();
+		}
 		
 		std::string sql() {
 #if SQLITE_VERSION_NUMBER >= 3014000
@@ -285,6 +289,10 @@ namespace sqlite {
 			});
 		}
 	};
+
+	inline void endr(database_binder& db) {
+	  db.endr();
+	}
 
 	namespace sql_function_binder {
 		template<
@@ -787,6 +795,24 @@ namespace sqlite {
 		val = i;
 	}
 
+	 /// apply a member function
+	 inline database_binder& operator <<(database_binder& db, void (database_binder::* pf)(void)) {
+	   (db.*pf)();
+	   return db;
+	 }
+
+	 /// apply a function pointer
+	 inline database_binder& operator<< (database_binder& db, void (*fun)(database_binder*)) {
+	   fun(&db);
+	   return db;
+	 }
+
+	 /// apply a lambda
+	 inline database_binder& operator<< (database_binder& db, std::function<void(database_binder&)>f) {
+	   f(db);
+	   return db;
+	 }
+
 	// std::optional support for NULL values
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val) {
@@ -893,6 +919,7 @@ namespace sqlite {
 
 	// Some ppl are lazy so we have a operator for proper prep. statemant handling.
 	void inline operator++(database_binder& db, int) { db.execute(); db.reset(); }
+
 
 	// Convert the rValue binder to a reference and call first op<<, its needed for the call that creates the binder (be carefull of recursion here!)
 	template<typename T> database_binder& operator << (database_binder&& db, const T& val) { return db << val; }

--- a/tests/prepared_statment.cc
+++ b/tests/prepared_statment.cc
@@ -99,6 +99,11 @@ int main() {
 
 		}
 
+		auto ppsc = db << "CREATE TABLE tnums(name VARCHAR(30) PRIMARY KEY ASC NOT NULL UNIQUE, num INT NOT NULL);";
+		auto ppsi = db << "INSERT INTO tnums VALUES (?,?);";
+		ppsi << "zero" << 0 << endr;
+		ppsi << [&](database_binder&dbi) { dbi << "one" << 1; } << endr;
+
 
 	} catch(sqlite_exception e) {
 		cout << "Unexpected error " << e.what() << endl;


### PR DESCRIPTION
We add the ability to force the end of a prepared statement with `endr` and the ability to give functions to them.