### PR TITLE
Auto reset after statement execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,10 @@ ps << tmp;
 // But beware that it will execute on destruction if it wasn't executed!
 ps >> [&](int a,int b){ ... };
 
-// after a successfull execution the statment needs to be reset to be execute again. This will reset the bound values too!
-ps.reset();
-
+// after a successfull execution the statment an be executed again, but the bound values are resetted.
 // If you dont need the returned values you can execute it like this
-ps.execute(); // the statment will not be reset!
-
-// there is a convinience operator to execute and reset in one go
+ps.execute();
+// or like this
 ps++;
 
 // To disable the execution of a statment when it goes out of scope and wasn't used

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ ps << tmp;
 // But beware that it will execute on destruction if it wasn't executed!
 ps >> [&](int a,int b){ ... };
 
-// after a successfull execution the statment an be executed again, but the bound values are resetted.
+// after a successfull execution the statment can be executed again, but the bound values are resetted.
 // If you dont need the returned values you can execute it like this
 ps.execute();
 // or like this

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -73,12 +73,6 @@ namespace sqlite {
 			_stmt(std::move(other._stmt)),
 			_inx(other._inx), execution_started(other.execution_started) { }
 
-		void reset[[deprecated]]() {
-			used(true);
-			_inx = 0;
-			used(false);
-		}
-
 		void execute() {
 			_start_execute();
 			int hresult;

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -37,7 +37,6 @@ namespace sqlite {
 		//Some additional errors are here for the C++ interface
 		class more_rows: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 		class no_rows: public sqlite_exception { using sqlite_exception::sqlite_exception; };
-		class [[deprecated]] reexecution: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements needed to be reset before calling them again in older versions
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 
 		static void throw_sqlite_error(const int& error_code, const std::string &sql = "") {

--- a/hdr/sqlite_modern_cpp/errors.h
+++ b/hdr/sqlite_modern_cpp/errors.h
@@ -37,7 +37,7 @@ namespace sqlite {
 		//Some additional errors are here for the C++ interface
 		class more_rows: public sqlite_exception { using sqlite_exception::sqlite_exception; };
 		class no_rows: public sqlite_exception { using sqlite_exception::sqlite_exception; };
-		class reexecution: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements need to be reset before calling them again 
+		class [[deprecated]] reexecution: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements needed to be reset before calling them again in older versions
 		class more_statements: public sqlite_exception { using sqlite_exception::sqlite_exception; }; // Prepared statements can only contain one statement
 
 		static void throw_sqlite_error(const int& error_code, const std::string &sql = "") {

--- a/tests/prepared_statment.cc
+++ b/tests/prepared_statment.cc
@@ -16,10 +16,8 @@ int main() {
 
 		pps >> test; // execute statement
 
-		pps.reset();
-
 		pps << 4; // bind a rvalue
-		pps++; // and execute and reset
+		pps++; // and execute
 
 		pps << 8 >> test;
 
@@ -81,22 +79,9 @@ int main() {
 			auto prep = db << "select ?";
 
 			prep << 5;
-
 			prep.execute();
-			try {
-				prep.execute();
-				exit(EXIT_FAILURE);
-			} catch(errors::reexecution& ex) {
-				// Thats ok here
-			} catch(...) {
-				exit(EXIT_FAILURE);
-			}
-
-			prep.reset();
-
 			prep << 6;
 			prep.execute();
-
 		}
 
 


### PR DESCRIPTION
Deprecate `reset()` and reset the statement after every execution to avoid bugs.
The patch changes the behaviour of `operator++` to no longer set `used(false)`.
This fixes the loop example in the README.