### PR TITLE
Adds an api to collect results into direct object and/or its stl-container

### DIFF
--- a/hdr/collectors.h
+++ b/hdr/collectors.h
@@ -1,0 +1,82 @@
+
+#ifndef SQLITE_COLLECTORS_H
+#define SQLITE_COLLECTORS_H
+
+#include <sqlite_modern_cpp.h>
+
+#if __cplusplus > 201402
+#define CPP14_SUPPORTED
+#endif
+
+#ifdef CPP14_SUPPORTED
+#define __COLLECTOR_RETURN_TYPE auto
+#define __COLLECTOR_CTOR_OF_T(T,X)		{X}
+#else
+#define __COLLECTOR_RETURN_TYPE 	std::function<void(Args...)>
+#define __COLLECTOR_CTOR_OF_T(T,X)		T(X)
+#endif
+
+template <typename ...Args>
+struct collect
+{
+	template<typename T, template<class, class...> class C>
+	inline static
+	__COLLECTOR_RETURN_TYPE
+	to(C<T> &container)
+	{
+		return [&container](const Args&... args)
+		{
+			container.push_back(__COLLECTOR_CTOR_OF_T(T,args...));
+		};
+	}
+
+	template<typename T, template<class, class...> class C>
+	inline static
+	__COLLECTOR_RETURN_TYPE
+	to(C<std::shared_ptr<T>> &container)
+	{
+		return [&container](const Args&... args)
+		{
+			container.push_back(std::make_shared<T>(args...));
+		};
+	}
+
+	template<template<class, class...> class C, typename T >
+	struct as
+	{
+		friend C<T> operator>>(sqlite::database_binder& db_binder, as<C,T>)
+		{
+			C<T> container;
+			db_binder>>to(container);
+			return container;
+		}
+		
+		friend C<T> operator>>(sqlite::database_binder&& db_binder, as<C,T>)
+		{
+			return db_binder>>as<C,T>();
+		}
+	};
+	
+	template<typename T >
+	struct as<std::shared_ptr,T>
+	{
+		friend std::shared_ptr<T> operator>>(sqlite::database_binder& db_binder, as<std::shared_ptr,T>)
+		{
+			std::shared_ptr<T> objP;
+			db_binder>>[&objP](Args... args)
+			{
+				objP = std::make_shared<T>(args...);
+			};
+			return objP;
+		}
+
+		friend std::shared_ptr<T> operator>>(sqlite::database_binder&& db_binder, as<std::shared_ptr,T> whatever)
+		{
+			return db_binder>>whatever;
+		}
+
+	};
+};
+
+
+#endif

--- a/tests/collector.cc
+++ b/tests/collector.cc
@@ -1,0 +1,88 @@
+
+#include "collectors.h"
+#include <list>
+#include <algorithm>
+
+using namespace std;
+using namespace sqlite;
+
+struct user
+{
+	int id;
+	string name;
+
+	user(int _id, string _name):id(_id),name(_name)
+	{
+		clog<<"object created : "<<*this<<"\n";
+	}
+
+	friend std::ostream& operator <<(std::ostream& out, const user& a)
+	{
+		out<<"<"<<a.id<<","<<a.name<<">";
+		return out;
+	}
+};
+
+
+database init_db()
+{
+	database db(":memory:");
+	db << "CREATE TABLE tbl (id integer, name string);";
+	db << "INSERT INTO tbl VALUES (?, ?);" << 1 << "hello";
+	db << "INSERT INTO tbl VALUES (?, ?);" << 2 << "world";
+
+	return db;
+}
+
+
+void test_single_user(database &db)
+{
+	auto may_be_user = db<<"SELECT * FROM tbl WHERE id = 1 ;"
+						>> collect<int,string>::as<shared_ptr,user>();
+	assert(may_be_user);
+	assert(may_be_user->name == "hello");
+}
+
+void test_multiple_user(database &db)
+{
+	auto all_users = db<<"SELECT * FROM tbl ;"
+						>> collect<int,string>::as<list,user>();
+	assert(not all_users.empty());
+	assert(any_of(all_users.begin(), all_users.end(), [](user u)
+	{
+		return u.name == "hello";
+	}));
+}
+
+void test_multiple_usernames(database &db)
+{
+	auto names = db<<"SELECT name FROM tbl ORDER BY id DESC;"
+						>> collect<string>::as<vector,string>();
+	assert(not names.empty());
+	assert(names[0] == "world");
+	assert(names[1] == "hello");
+}
+
+void test_append_results_to_container(database &db)
+{
+	list<int> ids = {-1,0,11};
+
+	db<<"SELECT id FROM tbl ;"
+		>>collect<int>::to(ids);
+
+	list<int> expected = { -1,0,11, 1, 2};
+	assert(ids == expected);
+}
+
+int main()
+{
+	database db=init_db();
+	
+	test_single_user(db);
+	test_multiple_user(db);
+	test_multiple_usernames(db);
+	
+	test_append_results_to_container(db);
+	
+	return 0;
+}


### PR DESCRIPTION
I've created this api for a better ORM like solution which works with sqlite_modern_cpp.

This api can collect multiple results 

1. to a container like (vector, list , ...etc) of object . (collect::to)
2. to a container like (vector, list , ...etc) of smart_pointers of object. (collect::to)
3. as fresh newly created stl-container of object. (collect::as)
4. as fresh newly created stl-container of smart_pointers of object. (collect::as)

Also this api can collect single results 

1.  as smart pointer (std::shared_ptr) of an object. (collect::as)

SUPPORTS BOTH c++11 and c++14. 