### PR TITLE
Allow whitespace after semicolons

### DIFF
--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -180,7 +180,7 @@ namespace sqlite {
 			const char *remaining;
 			hresult = sqlite3_prepare_v2(_db.get(), sql.data(), -1, &tmp, &remaining);
 			if(hresult != SQLITE_OK) errors::throw_sqlite_error(hresult, sql);
-			if(!std::all_of(remaining, sql.data() + sql.size(), [](char ch) {return std::isblank(ch);}))
+			if(!std::all_of(remaining, sql.data() + sql.size(), [](char ch) {return std::isspace(ch);}))
 				throw errors::more_statements("Multiple semicolon separated statements are unsupported", sql);
 			return tmp;
 		}

--- a/tests/simple_examples.cc
+++ b/tests/simple_examples.cc
@@ -11,7 +11,7 @@ int main()
 	{
 		database db(":memory:");
 
-		db << "CREATE TABLE foo (a integer, b string);";
+		db << "CREATE TABLE foo (a integer, b string);\n";
 		db << "INSERT INTO foo VALUES (?, ?)" << 1 << "hello";
 		db << "INSERT INTO foo VALUES (?, ?)" << 2 << "world";
 


### PR DESCRIPTION
Fix #131.

Similar problems may arise with comments after the semicolon, but I don't know how to fix this without effectively writing a parser for SQLite comments.