### PR TITLE
Adding std::experimental::optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ int main() {
 
 If you do not have C++17 support, you can use boost optional instead by defining `_MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT` before importing the `sqlite_modern_cpp` header.
 
-If your compiler does support C++17, but does not have optional (macOS for instance, at the time this was written), you can use std::experimental::optional instead by defining `_MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT` before importing the `sqlite_modern_cpp` header.
+If the optional library is not available, the experimental/optional one will be used instead.
 
 **Note: boost support is deprecated and will be removed in future versions.**
 

--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ int main() {
 
 If you do not have C++17 support, you can use boost optional instead by defining `_MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT` before importing the `sqlite_modern_cpp` header.
 
+If your compiler does support C++17, but does not have optional (macOS for instance, at the time this was written), you can use std::experimental::optional instead by defining `_MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT` before importing the `sqlite_modern_cpp` header.
+
 **Note: boost support is deprecated and will be removed in future versions.**
 
 Variant type support (C++17)

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -27,6 +27,8 @@
 
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #include <optional>
+#elif _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT && __has_include(<experimental/optional>)
+#include <experimental/optional>
 #endif
 
 #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -53,6 +53,18 @@
 #endif
 
 namespace sqlite {
+
+		// std::optional support for NULL values
+	#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+	#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+	template<class T>
+	using optional = std::experimental::optional<T>;
+	#else
+	template<class T>
+	using optional = std::optional<T>;
+	#endif
+	#endif
+
 	class database;
 	class database_binder;
 
@@ -247,13 +259,6 @@ namespace sqlite {
 
 
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-		#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
-		template<class T>
-		using optional = std::experimental::optional<T>;
-		#else
-		template<class T>
-		using optional = std::optional<T>;
-		#endif
 		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const optional<OptionalT>& val);
 		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o);
 #endif

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -30,16 +30,20 @@
   template<class T>
   using optional = std::optional<T>;
   #define MODERN_SQLITE_OPTIONAL_SUPPORT
-#elif _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT && __has_include(<experimental/optional>)
-  #include <experimental/optional>
-  template<class T>
-  using optional = std::experimental::optional<T>;
-  #define MODERN_SQLITE_OPTIONAL_SUPPORT
-#elif _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
-  #include <boost/optional.hpp>
-  template<class T>
-  using optional = boost::optional<T>;
-  #define MODERN_SQLITE_OPTIONAL_SUPPORT
+#elif __has_include(<experimental/optional>)
+  #ifdef _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+    #include <experimental/optional>
+    template<class T>
+    using optional = std::experimental::optional<T>;
+    #define MODERN_SQLITE_OPTIONAL_SUPPORT
+  #endif
+#else
+  #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
+    #include <boost/optional.hpp>
+    template<class T>
+    using optional = boost::optional<T>;
+    #define MODERN_SQLITE_OPTIONAL_SUPPORT
+  #endif
 #endif
 
 #include <sqlite3.h>

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -30,20 +30,16 @@
   template<class T>
   using optional = std::optional<T>;
   #define MODERN_SQLITE_OPTIONAL_SUPPORT
-#elif __has_include(<experimental/optional>)
-  #ifdef _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
-    #include <experimental/optional>
-    template<class T>
-    using optional = std::experimental::optional<T>;
-    #define MODERN_SQLITE_OPTIONAL_SUPPORT
-  #endif
-#else
-  #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
-    #include <boost/optional.hpp>
-    template<class T>
-    using optional = boost::optional<T>;
-    #define MODERN_SQLITE_OPTIONAL_SUPPORT
-  #endif
+#elif _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT && __has_include(<experimental/optional>)
+  #include <experimental/optional>
+  template<class T>
+  using optional = std::experimental::optional<T>;
+  #define MODERN_SQLITE_OPTIONAL_SUPPORT
+#elif _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
+  #include <boost/optional.hpp>
+  template<class T>
+  using optional = boost::optional<T>;
+  #define MODERN_SQLITE_OPTIONAL_SUPPORT
 #endif
 
 #include <sqlite3.h>

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -26,13 +26,20 @@
 #endif
 
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-#include <optional>
+  #include <optional>
+  template<class T>
+  using optional = std::optional<T>;
+  #define MODERN_SQLITE_OPTIONAL_SUPPORT
 #elif _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT && __has_include(<experimental/optional>)
-#include <experimental/optional>
-#endif
-
-#ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
-#include <boost/optional.hpp>
+  #include <experimental/optional>
+  template<class T>
+  using optional = std::experimental::optional<T>;
+  #define MODERN_SQLITE_OPTIONAL_SUPPORT
+#elif _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
+  #include <boost/optional.hpp>
+  template<class T>
+  using optional = boost::optional<T>;
+  #define MODERN_SQLITE_OPTIONAL_SUPPORT
 #endif
 
 #include <sqlite3.h>
@@ -239,14 +246,9 @@ namespace sqlite {
 		friend database_binder& operator <<(database_binder& db, const std::u16string& txt);
 
 
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val);
-		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, std::optional<OptionalT>& o);
-#endif
-
-#ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
-		template <typename BoostOptionalT> friend database_binder& operator <<(database_binder& db, const boost::optional<BoostOptionalT>& val);
-		template <typename BoostOptionalT> friend void get_col_from_db(database_binder& db, int inx, boost::optional<BoostOptionalT>& o);
+#ifdef MODERN_SQLITE_OPTIONAL_SUPPORT
+		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const optional<OptionalT>& val);
+		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o);
 #endif
 
 	public:
@@ -790,23 +792,23 @@ namespace sqlite {
 		val = i;
 	}
 
-	// std::optional support for NULL values
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val) {
+	// optional support for NULL values, whether std::optional, std::experimental::optional or boost:optional
+#ifdef MODERN_SQLITE_OPTIONAL_SUPPORT
+	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const optional<OptionalT>& val) {
 		if(val) {
 			return db << std::move(*val);
 		} else {
 			return db << nullptr;
 		}
 	}
-	template <typename OptionalT> inline void store_result_in_db(sqlite3_context* db, const std::optional<OptionalT>& val) {
+	template <typename OptionalT> inline void store_result_in_db(sqlite3_context* db, const optional<OptionalT>& val) {
 		if(val) {
 			store_result_in_db(db, *val);
 		}
 		sqlite3_result_null(db);
 	}
 
-	template <typename OptionalT> inline void get_col_from_db(database_binder& db, int inx, std::optional<OptionalT>& o) {
+	template <typename OptionalT> inline void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o) {
 		if(sqlite3_column_type(db._stmt.get(), inx) == SQLITE_NULL) {
 			o.reset();
 		} else {
@@ -815,47 +817,11 @@ namespace sqlite {
 			o = std::move(v);
 		}
 	}
-	template <typename OptionalT> inline void get_val_from_db(sqlite3_value *value, std::optional<OptionalT>& o) {
+	template <typename OptionalT> inline void get_val_from_db(sqlite3_value *value, optional<OptionalT>& o) {
 		if(sqlite3_value_type(value) == SQLITE_NULL) {
 			o.reset();
 		} else {
 			OptionalT v;
-			get_val_from_db(value, v);
-			o = std::move(v);
-		}
-	}
-#endif
-
-	// boost::optional support for NULL values
-#ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
-	template <typename BoostOptionalT> inline database_binder& operator <<(database_binder& db, const boost::optional<BoostOptionalT>& val) {
-		if(val) {
-			return db << std::move(*val);
-		} else {
-			return db << nullptr;
-		}
-	}
-	template <typename BoostOptionalT> inline void store_result_in_db(sqlite3_context* db, const boost::optional<BoostOptionalT>& val) {
-		if(val) {
-			store_result_in_db(db, *val);
-		}
-		sqlite3_result_null(db);
-	}
-
-	template <typename BoostOptionalT> inline void get_col_from_db(database_binder& db, int inx, boost::optional<BoostOptionalT>& o) {
-		if(sqlite3_column_type(db._stmt.get(), inx) == SQLITE_NULL) {
-			o.reset();
-		} else {
-			BoostOptionalT v;
-			get_col_from_db(db, inx, v);
-			o = std::move(v);
-		}
-	}
-	template <typename BoostOptionalT> inline void get_val_from_db(sqlite3_value *value, boost::optional<BoostOptionalT>& o) {
-		if(sqlite3_value_type(value) == SQLITE_NULL) {
-			o.reset();
-		} else {
-			BoostOptionalT v;
 			get_val_from_db(value, v);
 			o = std::move(v);
 		}

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -16,6 +16,10 @@
 #ifdef __has_include
 #if __cplusplus > 201402 && __has_include(<optional>)
 #define MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+#elif __has_include(<experimental/optional>)
+#ifdef _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+#define MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+#endif
 #endif
 #endif
 
@@ -27,7 +31,9 @@
 
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #include <optional>
-#elif _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT && __has_include(<experimental/optional>)
+#endif
+
+#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
 #include <experimental/optional>
 #endif
 
@@ -239,9 +245,16 @@ namespace sqlite {
 		friend database_binder& operator <<(database_binder& db, const std::u16string& txt);
 
 
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val);
-		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, std::optional<OptionalT>& o);
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT || MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+		#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+		template<class T>
+		using optional = std::optional<T>;
+		#else
+		template<class T>
+		using optional = std::experimental::optional<T>;
+		#endif
+		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const optional<OptionalT>& val);
+		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o);
 #endif
 
 #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
@@ -791,22 +804,22 @@ namespace sqlite {
 	}
 
 	// std::optional support for NULL values
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const std::optional<OptionalT>& val) {
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT || MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const optional<OptionalT>& val) {
 		if(val) {
 			return db << std::move(*val);
 		} else {
 			return db << nullptr;
 		}
 	}
-	template <typename OptionalT> inline void store_result_in_db(sqlite3_context* db, const std::optional<OptionalT>& val) {
+	template <typename OptionalT> inline void store_result_in_db(sqlite3_context* db, const optional<OptionalT>& val) {
 		if(val) {
 			store_result_in_db(db, *val);
 		}
 		sqlite3_result_null(db);
 	}
 
-	template <typename OptionalT> inline void get_col_from_db(database_binder& db, int inx, std::optional<OptionalT>& o) {
+	template <typename OptionalT> inline void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o) {
 		if(sqlite3_column_type(db._stmt.get(), inx) == SQLITE_NULL) {
 			o.reset();
 		} else {
@@ -815,7 +828,7 @@ namespace sqlite {
 			o = std::move(v);
 		}
 	}
-	template <typename OptionalT> inline void get_val_from_db(sqlite3_value *value, std::optional<OptionalT>& o) {
+	template <typename OptionalT> inline void get_val_from_db(sqlite3_value *value, optional<OptionalT>& o) {
 		if(sqlite3_value_type(value) == SQLITE_NULL) {
 			o.reset();
 		} else {

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -825,7 +825,11 @@ namespace sqlite {
 
 	template <typename OptionalT> inline void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o) {
 		if(sqlite3_column_type(db._stmt.get(), inx) == SQLITE_NULL) {
+			#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+			o = std::experimental::nullopt;
+			#else
 			o.reset();
+			#endif
 		} else {
 			OptionalT v;
 			get_col_from_db(db, inx, v);
@@ -834,7 +838,11 @@ namespace sqlite {
 	}
 	template <typename OptionalT> inline void get_val_from_db(sqlite3_value *value, optional<OptionalT>& o) {
 		if(sqlite3_value_type(value) == SQLITE_NULL) {
+			#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+			o = std::experimental::nullopt;
+			#else
 			o.reset();
+			#endif
 		} else {
 			OptionalT v;
 			get_val_from_db(value, v);

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -35,6 +35,7 @@
 
 #ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
 #include <experimental/optional>
+#define MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #endif
 
 #ifdef _MODERN_SQLITE_BOOST_OPTIONAL_SUPPORT
@@ -245,13 +246,13 @@ namespace sqlite {
 		friend database_binder& operator <<(database_binder& db, const std::u16string& txt);
 
 
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT || MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
-		#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
-		template<class T>
-		using optional = std::optional<T>;
-		#else
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
+		#ifdef MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
 		template<class T>
 		using optional = std::experimental::optional<T>;
+		#else
+		template<class T>
+		using optional = std::optional<T>;
 		#endif
 		template <typename OptionalT> friend database_binder& operator <<(database_binder& db, const optional<OptionalT>& val);
 		template <typename OptionalT> friend void get_col_from_db(database_binder& db, int inx, optional<OptionalT>& o);
@@ -804,7 +805,7 @@ namespace sqlite {
 	}
 
 	// std::optional support for NULL values
-#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT || MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
+#ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 	template <typename OptionalT> inline database_binder& operator <<(database_binder& db, const optional<OptionalT>& val) {
 		if(val) {
 			return db << std::move(*val);

--- a/hdr/sqlite_modern_cpp.h
+++ b/hdr/sqlite_modern_cpp.h
@@ -17,9 +17,7 @@
 #if __cplusplus > 201402 && __has_include(<optional>)
 #define MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 #elif __has_include(<experimental/optional>)
-#ifdef _MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
 #define MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT
-#endif
 #endif
 #endif
 

--- a/tests/std_optional.cc
+++ b/tests/std_optional.cc
@@ -8,7 +8,7 @@ using namespace std;
 #ifdef MODERN_SQLITE_STD_OPTIONAL_SUPPORT
 void insert(database& db, bool is_null) {
 	int id = 1;
-	std::optional<int> val;
+	sqlite::optional<int> val;
 	if(!is_null) val = 5;
 
 	db << "delete from test where id = 1";
@@ -16,7 +16,7 @@ void insert(database& db, bool is_null) {
 }
 
 void select(database& db, bool should_be_null) {
-	db << "select id,val from test" >> [&](long long, std::optional<int> val) {
+	db << "select id,val from test" >> [&](long long, sqlite::optional<int> val) {
 		if(should_be_null) {
 			if(val) exit(EXIT_FAILURE);
 		} else {


### PR DESCRIPTION
On macOS, despite the compiler already supporting std::optional, it seems the optional library does not yet exist, meaning we have to rely on std::experimental optional.

I have added that possibility by adding a check for `_MODERN_SQLITE_EXPERIMENTAL_OPTIONAL_SUPPORT`, similar to what is done for the boost::optional. It was implemented in such a way that the experimental::optional is only used if explicitly requested and available.

I also consolidated the implementation of the different optional types. apart from belonging to different namespaces, all optional types work the same, so they were merged together, using the ```using optional = std::optional<T>``` idiom.

The changes should not break existing code which depends on the previous behaviour, but I do not have the normal optional library nor boost installed, so I can not test this.